### PR TITLE
Native compiler code cleanup & a bug fix

### DIFF
--- a/cmd/main.js
+++ b/cmd/main.js
@@ -22,7 +22,9 @@ if( cli.build ) {
     // Run our build pipeline.
     pipelines
         .JSBuildPipeline(workspace.getSourceDir(),
-                         workspace.getIgnoreGlobs())
+                         workspace.getIgnoreGlobs(),
+                         workspace.getPreprocessorVars(),
+                         console)
 
         // Write output to filesystem.
         .pipe(workspace.getBuildDest());
@@ -50,7 +52,8 @@ if( cli.build ) {
         initStream = pipelines
             .BuildPipeline(workspace.getSourceDir(),
                            workspace.getIgnoreGlobs(),
-                           workspace.getPreprocessorVars())
+                           workspace.getPreprocessorVars(),
+                           console)
             .pipe(workspace.getBuildDest());
     }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -77,13 +77,17 @@ class NativeCompiler {
         });
 
         var output = JSON.parse(child_process.execSync(
-                "solc -o - --combined-json abi,bin,bin-runtime "
+                "solc -o - --combined-json abi,bin,interface "
                 + Object.keys(sources).join(" "), {cwd: tmpDir}));
 
         fs.removeSync(tmpDir); // Clean up.
 
         output.contracts = _.mapValues(output.contracts, function (contract) {
-            return {bytecode: contract.bin, interface: contract.abi};
+            return {
+                "bytecode": contract.bin,
+                "interface": contract.abi,
+                "solidity_interface": contract.interface
+            };
         });
         return output;
     }

--- a/lib/build.js
+++ b/lib/build.js
@@ -29,27 +29,45 @@ module.exports = class Builder {
     // Solidity source code. Prefers a native `solc` installation
     // if one is available. Fails over to a Javascript `solc`
     // implementation if one is not.
-    static buildSources(sources) {
-        var useNative = true;
-
-        try {
-            child_process.execSync("solc");
-
-        } catch (err) {
-            useNative = false;
-        }
-
-        if (useNative) {
-            console.log("Using local solc installation...");
-            return this.nativeBuildSources(sources);
+    static buildSources(sources, logger) {
+        var compiler = solc;
+        if (NativeCompiler.isAvailable()) {
+            logger.info("Using local solc installation...");
+            compiler = NativeCompiler;
 
         } else {
-            console.log("No local solc found. Failing over to JS compiler...");
-            return this.jsBuildSources(sources);
+            logger.info("No local solc found. Failing over to JS compiler...");
         }
+
+        var solc_out = compiler.compile({sources:sources});
+        if( solc_out.errors ) {
+            throw solc_out.errors;
+        }
+        return solc_out;
     }
 
-    static nativeBuildSources(sources) {
+    // Filters out useless solc output
+    static removeSolcClutter(sources) {
+        var bad_keys =  ["assembly", "opcodes"];
+        return _.mapValues(sources, function(_class, classname) {
+            var omitted = _.omit(_class, bad_keys);
+            return omitted;
+        });
+    }
+};
+
+class NativeCompiler {
+    static isAvailable() {
+        try {
+            child_process.execSync("solc");
+        } catch (err) {
+            return false;
+        }
+        return true;
+    }
+
+    static compile(input) {
+        var sources = input.sources;
         var tmpDir = path.join(os.tmpdir(), 'dapple',
                                String(Math.random()).slice(2));
         fs.emptyDirSync(tmpDir); // Create or empty the directory. 
@@ -69,21 +87,4 @@ module.exports = class Builder {
         });
         return output;
     }
-
-    static jsBuildSources(sources) {
-        var solc_out = solc.compile({sources:sources});
-        if( solc_out.errors ) {
-            throw solc_out.errors;
-        }
-        return solc_out;
-    }
-
-    // Filters out useless solc output
-    static removeSolcClutter(sources) {
-        var bad_keys =  ["assembly", "opcodes"];
-        return _.mapValues(sources, function(_class, classname) {
-            var omitted = _.omit(_class, bad_keys);
-            return omitted;
-        });
-    }
-};
+}

--- a/lib/pipelines.js
+++ b/lib/pipelines.js
@@ -31,7 +31,8 @@ var PackagePipeline = function (sourceRoot, ignoreGlobs) {
 
 // Returns raw output of `solc`.
 // **TODO**: Remove need for `sourceRoot` via intelligent file linking.
-var BuildPipeline = function (sourceRoot, ignoreGlobs, preprocessorVars) {
+var BuildPipeline = function (
+        sourceRoot, ignoreGlobs, preprocessorVars, logger) {
 
     return Combine(
         PackagePipeline(sourceRoot, ignoreGlobs),
@@ -49,14 +50,15 @@ var BuildPipeline = function (sourceRoot, ignoreGlobs, preprocessorVars) {
         //...
 
         // Build!
-        streams.build());
+        streams.build(logger));
 };
 
 
 // Builds JS-specific output.
-var JSBuildPipeline = function (sourceRoot, ignoreGlobs) {
+var JSBuildPipeline = function (
+        sourceRoot, ignoreGlobs, preprocessorVars, logger) {
     return Combine(
-            BuildPipeline(sourceRoot, ignoreGlobs),
+            BuildPipeline(sourceRoot, ignoreGlobs, preprocessorVars, logger),
             streams.js_postprocess());
 };
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -94,7 +94,7 @@ var preprocess = function (preprocessorVars) {
 
 // This stream takes Solidity contract files and hands them off to the Solidity
 // compiler and passes it on.
-var build = function () {
+var build = function (logger) {
     var sources = {};
 
     return through.obj(function (file, enc, cb) {
@@ -104,7 +104,7 @@ var build = function () {
         cb();
 
     }, function (cb) {
-        var solc_out = Builder.buildSources(sources);
+        var solc_out = Builder.buildSources(sources, logger);
 
         this.push(new File({
             path: 'classes.json',

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -110,6 +110,7 @@ var build = function (logger) {
             path: 'classes.json',
             contents: new Buffer(JSON.stringify(solc_out.contracts))
         }));
+        cb();
     });
 };
 
@@ -285,7 +286,6 @@ var cli_out = function () {
         out("  " + String(file.contents));
         this.push(file);
         cb();
-
     });
 };
 


### PR DESCRIPTION
`dapple test` now shows a testing summary at the end, just like `dapple test --skip-build` does.