### PR TITLE
Fix log_address() and log_named_address()

### DIFF
--- a/lib/logtranslator.js
+++ b/lib/logtranslator.js
@@ -13,7 +13,8 @@ const hexTranslators = {
     "bytes": (hex) => web3.toAscii(hex).replace(/\u0000/g, ''),
     "string": (hex) => web3.toAscii(hex).replace(/\u0000/g, ''),
     "int": (hex) => web3.toBigNumber(hex).toString(),
-    "uint": (hex) => web3.toBigNumber(hex).toString()
+    "uint": (hex) => web3.toBigNumber(hex).toString(),
+    "address": (hex) => hex
 };
 
 module.exports = class LogTranslator {


### PR DESCRIPTION
I believe address is a native type in solidity and deserves it's own handling. I looked at ./test/logtranslator_test.js to add a test but am not sure the entry and translation structures being only json have the ability to express all solidity types. 